### PR TITLE
Made main layout a grid display

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,173 +12,173 @@
     <hr>
     <h4>From Wikipedia, the free encyclopedia</h4>
     <div class="content">
-    <div class="intro">
-        <p> <strong>Sara Beth Bareilles</strong> (/bəˈrɛlɪs/; born December 7, 1979)[1] is an American singer-songwriter and actress.</p>
-        <p>Bareilles achieved mainstream success in 2007 with the hit single "Love Song", which reached no. 4 on the Billboard Hot 100 chart.[2] In the third season of NBC's The Sing-Off, Bareilles served as a celebrity judge alongside Ben Folds and Shawn Stockman. She composed music and wrote lyrics for the Broadway musical Waitress, for which she earned a Tony Award nomination for Best Original Score in 2016, and a Grammy nomination for Best Musical Theatre Album. In April 2018, Bareilles received acclaim for her portrayal of Mary Magdalene in NBC's adaptation of a classic Andrew Lloyd Webber and Tim Rice rock opera, Jesus Christ Superstar Live in Concert, for which she was nominated for the 2018 Primetime Emmy Award for Outstanding Supporting Actress in a Limited Series or Movie.</p>
-        <p>Bareilles has sold over one million albums and over nine million singles and downloads in the United States and has earned seven Grammy Award nominations, including one Album of the Year nomination for The Blessed Unrest (2013).[3] In February 2012, VH1 placed Bareilles in the 80th spot of the Top 100 Greatest Women in Music.[4] Her memoir, Sounds Like Me: My Life (So Far) in Song, was published in 2015; The New York Times listed it as a bestseller.[5]</p>
-    </div>
-    <div class="sidebar" id="sidebar">
-        <div class="sidebarTitle"><b>Sara Bareilles</b></div>
-        <div class="photobox">
-            <img class="photo" src="440px-Sara_Bareilles.jpg" alt="Sara Bareilles sitting at the piano and singing" width="200px">
-            <div class="caption">Bareilles performing at the Troubadour in West Hollywood, California in October 2015</div>
+        <div class="intro">
+            <p> <strong>Sara Beth Bareilles</strong> (/bəˈrɛlɪs/; born December 7, 1979)[1] is an American singer-songwriter and actress.</p>
+            <p>Bareilles achieved mainstream success in 2007 with the hit single "Love Song", which reached no. 4 on the Billboard Hot 100 chart.[2] In the third season of NBC's The Sing-Off, Bareilles served as a celebrity judge alongside Ben Folds and Shawn Stockman. She composed music and wrote lyrics for the Broadway musical Waitress, for which she earned a Tony Award nomination for Best Original Score in 2016, and a Grammy nomination for Best Musical Theatre Album. In April 2018, Bareilles received acclaim for her portrayal of Mary Magdalene in NBC's adaptation of a classic Andrew Lloyd Webber and Tim Rice rock opera, Jesus Christ Superstar Live in Concert, for which she was nominated for the 2018 Primetime Emmy Award for Outstanding Supporting Actress in a Limited Series or Movie.</p>
+            <p>Bareilles has sold over one million albums and over nine million singles and downloads in the United States and has earned seven Grammy Award nominations, including one Album of the Year nomination for The Blessed Unrest (2013).[3] In February 2012, VH1 placed Bareilles in the 80th spot of the Top 100 Greatest Women in Music.[4] Her memoir, Sounds Like Me: My Life (So Far) in Song, was published in 2015; The New York Times listed it as a bestseller.[5]</p>
         </div>
-        <div class="infoItem">
-            <span class="infoItemTitle"><b>Born</b></span>
-            <span class="infoItemText">Sara Beth Bareilles</span>
-        </div>
-        <div class="infoItem">
-                <span class="infoItemTitle">   </span>
-                <span class="infoItemText">December 7, 1979 (age 39)</span>
-        </div>
-        <div class="infoItem">
-                <span class="infoItemTitle">  </span>
-                <span class="infoItemText">Eureka Springs, California</span>
-        </div>
-        <div class="infoItem">
-            <span class="infoItemTitle"><b>Alma mater</b></span>
-            <span class="infoItemText"><a href="https://en.wikipedia.org/wiki/University_of_California,_Los_Angeles">University of California, Los Angeles</a></span>
-        </div>
-        <div class="infoItem">
-            <span class="infoItemTitle"><b>Occupation</b></span>
-            <span class="infoItemText">Singer-songwriter - Actor</span>
-        </div>
-        <div class="infoItem">
-            <span class="infoItemTitle"><b>Years active</b></span>
-            <span class="infoItemText">2002-present</span>
-        </div>
-        <div class="infoItem">
-            <span class="infoItemTitle"><b>Partner(s)</b></span>
-            <span class="infoItemText">Joe Tippett (2015-)</span>
-        </div>
+        <div class="sidebar" id="sidebar">
+            <div class="sidebarTitle"><b>Sara Bareilles</b></div>
+            <div class="photobox">
+                <img class="photo" src="440px-Sara_Bareilles.jpg" alt="Sara Bareilles sitting at the piano and singing" width="200px">
+                <div class="caption">Bareilles performing at the Troubadour in West Hollywood, California in October 2015</div>
+            </div>
+            <div class="infoItem">
+                <span class="infoItemTitle"><b>Born</b></span>
+                <span class="infoItemText">Sara Beth Bareilles</span>
+            </div>
+            <div class="infoItem">
+                    <span class="infoItemTitle">   </span>
+                    <span class="infoItemText">December 7, 1979 (age 39)</span>
+            </div>
+            <div class="infoItem">
+                    <span class="infoItemTitle">  </span>
+                    <span class="infoItemText">Eureka Springs, California</span>
+            </div>
+            <div class="infoItem">
+                <span class="infoItemTitle"><b>Alma mater</b></span>
+                <span class="infoItemText"><a href="https://en.wikipedia.org/wiki/University_of_California,_Los_Angeles">University of California, Los Angeles</a></span>
+            </div>
+            <div class="infoItem">
+                <span class="infoItemTitle"><b>Occupation</b></span>
+                <span class="infoItemText">Singer-songwriter - Actor</span>
+            </div>
+            <div class="infoItem">
+                <span class="infoItemTitle"><b>Years active</b></span>
+                <span class="infoItemText">2002-present</span>
+            </div>
+            <div class="infoItem">
+                <span class="infoItemTitle"><b>Partner(s)</b></span>
+                <span class="infoItemText">Joe Tippett (2015-)</span>
+            </div>
 
-    </div>
-    <div class="contentsBox">
-        <div class="tocTitle"><strong>Contents</strong>[hide]</div>
-        <ul class="contentsSection">
-            <li> 
-                <a href="#Life and career">
-                <span class="contentsNum">1</span>
-                <span class="contentsText">Life and career</span>
-                </a>
-            </li></ul>
-            <ul class="subSection">
-                <li>
-                    <a href="#1979-2001: Early Life">
-                        <span class="subNum">1.1</span>
-                        <span class="subText">1979-2001: Early life</span>
-                    </a></li>   
-                <li>
-                    <a href="#2002-2006: Career beginnings and Careful Confessions">
-                        <span class="subNum">1.2</span>
-                        <span class="subText">2002-2006: Career beginnings and <i>Careful Confessions</i></span>
-                    </a></li>
-                <li>
-                    <a href="#2007-2008: Break through with Little Voice">
-                         <span class="subNum">1.3</span>
-                         <span class="subText">2007-2008: Break through with <i>Little Voice</i></span>
-                    </a></li>
-                <li>
-                    <a href="#2009-2012: Kaleidoscope Heart and The Sing-Off">
-                        <span class="subNum">1.4</span>
-                        <span class="subText">2009-2012: <i>Kaleidoscope Heart</i> and <i>The Sing-Off</i></span>
-                    </a></li>
-                <li>
-                    <a href="#2012-2014: Once Upon Another Time EP and The Blessed Unrest">
-                        <span class="subNum">1.5</span>
-                        <span class="subText">2012-2014: <i>Once Upon Another Time</i> EP and <i>The Blessed Unrest</i></span>
-                    </a></li>
-                <li>
-                    <a href="#2015-2017: Waitress, Sounds Like Me, and What's Inside">
-                        <span class="subNum">1.6</span>
-                        <span class="subText">2015-2017: <i>Waitress, Sounds Like Me,></i> and <i>What's Inside</i></span>
-                    </a></li>
-                <li>
-                    <a href="#2018-present: Jesus Christ Superstar and Amidst the Chaos">
-                        <span class="subNum">1.6</span>
-                        <span class="subText">2018-present: <i>Jesus Christ Superstar</i> and <i>Amidst the Chaos</i></span>
-                    </a></li>
-            </ul>        
-        </ul>
-        <ul class="contentsSection">
-            <li> 
-                <a href="#Artistry">
-                    <span class="contentsNum">2</span>
-                    <span class="contentsText">Artistry</span>
-                </a></li>
+        </div>
+        <div class="contentsBox">
+            <div class="tocTitle"><strong>Contents</strong>[hide]</div>
+            <ul class="contentsSection">
+                <li> 
+                    <a href="#Life and career">
+                    <span class="contentsNum">1</span>
+                    <span class="contentsText">Life and career</span>
+                    </a>
+                </li></ul>
                 <ul class="subSection">
                     <li>
-                        <a href="#Musical style and influences">
-                            <span class="subNum">2.1</span>
-                            <span class="subText">Musical style and influences</span>
+                        <a href="#1979-2001: Early Life">
+                            <span class="subNum">1.1</span>
+                            <span class="subText">1979-2001: Early life</span>
                         </a></li>   
                     <li>
-                        <a href="#Band members">
-                            <span class="subNum">2.2</span>
-                            <span class="subText">Band members</span>
+                        <a href="#2002-2006: Career beginnings and Careful Confessions">
+                            <span class="subNum">1.2</span>
+                            <span class="subText">2002-2006: Career beginnings and <i>Careful Confessions</i></span>
                         </a></li>
                     <li>
-                        <a href="#Collaborations with other artists">
-                            <span class="subNum">2.3</span>
-                            <span class="subText">Collaborations with other artists</span>
+                        <a href="#2007-2008: Break through with Little Voice">
+                            <span class="subNum">1.3</span>
+                            <span class="subText">2007-2008: Break through with <i>Little Voice</i></span>
                         </a></li>
-                </ul>
-        </ul>
-        <ul class="contentsSection">
-            <li> 
-                <a href="#Personal Life">
-                    <span class="contentsNum">3</span>
-                    <span class="contentsText">Personal Life</span>
-                </a></li>
-        </ul>
-        <ul class="contentsSection">
+                    <li>
+                        <a href="#2009-2012: Kaleidoscope Heart and The Sing-Off">
+                            <span class="subNum">1.4</span>
+                            <span class="subText">2009-2012: <i>Kaleidoscope Heart</i> and <i>The Sing-Off</i></span>
+                        </a></li>
+                    <li>
+                        <a href="#2012-2014: Once Upon Another Time EP and The Blessed Unrest">
+                            <span class="subNum">1.5</span>
+                            <span class="subText">2012-2014: <i>Once Upon Another Time</i> EP and <i>The Blessed Unrest</i></span>
+                        </a></li>
+                    <li>
+                        <a href="#2015-2017: Waitress, Sounds Like Me, and What's Inside">
+                            <span class="subNum">1.6</span>
+                            <span class="subText">2015-2017: <i>Waitress, Sounds Like Me,></i> and <i>What's Inside</i></span>
+                        </a></li>
+                    <li>
+                        <a href="#2018-present: Jesus Christ Superstar and Amidst the Chaos">
+                            <span class="subNum">1.6</span>
+                            <span class="subText">2018-present: <i>Jesus Christ Superstar</i> and <i>Amidst the Chaos</i></span>
+                        </a></li>
+                </ul>        
+            </ul>
+            <ul class="contentsSection">
                 <li> 
-                    <a href="#Discography">
-                        <span class="contentsNum">4</span>
-                        <span class="contentsText">Discography</span>
+                    <a href="#Artistry">
+                        <span class="contentsNum">2</span>
+                        <span class="contentsText">Artistry</span>
                     </a></li>
-        </ul>
-        <ul class="contentsSection">
+                    <ul class="subSection">
+                        <li>
+                            <a href="#Musical style and influences">
+                                <span class="subNum">2.1</span>
+                                <span class="subText">Musical style and influences</span>
+                            </a></li>   
+                        <li>
+                            <a href="#Band members">
+                                <span class="subNum">2.2</span>
+                                <span class="subText">Band members</span>
+                            </a></li>
+                        <li>
+                            <a href="#Collaborations with other artists">
+                                <span class="subNum">2.3</span>
+                                <span class="subText">Collaborations with other artists</span>
+                            </a></li>
+                    </ul>
+            </ul>
+            <ul class="contentsSection">
                 <li> 
-                    <a href="#Filmography">
-                        <span class="contentsNum">5</span>
-                        <span class="contentsText">Filmography</span>
+                    <a href="#Personal Life">
+                        <span class="contentsNum">3</span>
+                        <span class="contentsText">Personal Life</span>
                     </a></li>
-                <ul class="subSection">
-                    <li>
-                        <a href="#Television and film">
-                            <span class="subNum">5.1</span>
-                            <span class="subText">Television and film</span>
-                        </a></li>   
-                    <li>
-                        <a href="#Theatre credits">
-                            <span class="subNum">5.2</span>
-                             <span class="subText">Theatre credits</span>
+            </ul>
+            <ul class="contentsSection">
+                    <li> 
+                        <a href="#Discography">
+                            <span class="contentsNum">4</span>
+                            <span class="contentsText">Discography</span>
                         </a></li>
-                </ul>
-        </ul>
-        <ul class="contentsSection">
-            <li> 
-                <a href="#Awards and nominations">
-                    <span class="contentsNum">6</span>
-                    <span class="contentsText">Awards and nominations</span>
-                </a></li>
-        </ul>
-        <ul class="contentsSection">
-            <li> 
-                <a href="#References">
-                    <span class="contentsNum">7</span>
-                    <span class="contentsText">References</span>
-                </a></li>
-        </ul>
-        <ul class="contentsSection">
-            <li> 
-                <a href="#External links">
-                    <span class="contentsNum">8</span>
-                    <span class="contentsText">External links</span>
-                </a></li>
-        </ul>
-    </div>
+            </ul>
+            <ul class="contentsSection">
+                    <li> 
+                        <a href="#Filmography">
+                            <span class="contentsNum">5</span>
+                            <span class="contentsText">Filmography</span>
+                        </a></li>
+                    <ul class="subSection">
+                        <li>
+                            <a href="#Television and film">
+                                <span class="subNum">5.1</span>
+                                <span class="subText">Television and film</span>
+                            </a></li>   
+                        <li>
+                            <a href="#Theatre credits">
+                                <span class="subNum">5.2</span>
+                                <span class="subText">Theatre credits</span>
+                            </a></li>
+                    </ul>
+            </ul>
+            <ul class="contentsSection">
+                <li> 
+                    <a href="#Awards and nominations">
+                        <span class="contentsNum">6</span>
+                        <span class="contentsText">Awards and nominations</span>
+                    </a></li>
+            </ul>
+            <ul class="contentsSection">
+                <li> 
+                    <a href="#References">
+                        <span class="contentsNum">7</span>
+                        <span class="contentsText">References</span>
+                    </a></li>
+            </ul>
+            <ul class="contentsSection">
+                <li> 
+                    <a href="#External links">
+                        <span class="contentsNum">8</span>
+                        <span class="contentsText">External links</span>
+                    </a></li>
+            </ul>
+        </div>
 
     
     </div>  

--- a/main.css
+++ b/main.css
@@ -11,10 +11,17 @@ h1 {
     text-align: center;
 }
 
-/* 
+
 .content {
-    display: inline-block;
-} */
+    display: grid;
+    grid-template-rows: auto;
+    grid-column-gap: 1%;
+    grid-template-areas: 
+      "intro intro intro sidebar"
+      "intro intro intro sidebar"
+      "contentsBox contentsBox . sidebar"
+      "contentsBox contentsBox . .";
+}
 
 .contentsBox {
     box-sizing: border-box;
@@ -23,18 +30,18 @@ h1 {
     background-color: rgb(240, 240, 240);
     float: left;
     font-size: 13px;
-    line-height: 21px;   
+    line-height: 21px;  
+    grid-area: contentsBox; 
 }
 
 .sidebar {
     
-    float: right;
-    display: inline-block;
     padding: 8px;
     box-sizing: border-box;
     width: 250px;
     border: 1px solid grey;
     background-color: rgb(240, 240, 240);
+    grid-area: sidebar;
 }
 
 .sidebarTitle {
@@ -61,9 +68,9 @@ h1 {
 }
 
 .intro {
-    display: inline-block;
     font-size: 14px;
     clear: both;
+    grid-area: intro;
 }
 
 .contentsSection {


### PR DESCRIPTION
Hey Jessica! Here is a way to be able to format the wiki page copy to the same as the actual wiki page. I used a css display type called grid which is kind of similar to flexbox but a little more powerful. You can check it out here: https://css-tricks.com/snippets/css/complete-guide-grid/